### PR TITLE
Example PR of why to delete images created during a pull request

### DIFF
--- a/images/variables-pipeline.json
+++ b/images/variables-pipeline.json
@@ -4,5 +4,5 @@
     "consul_version_number": "1.6.2",
     "vault_version_number": "1.3.0",
     "sig_replication_regions": "East US",
-    "sig_version": "0.0.2"
+    "sig_version": "0.0.3"
 }

--- a/images/variables-pipeline.json
+++ b/images/variables-pipeline.json
@@ -4,5 +4,5 @@
     "consul_version_number": "1.6.2",
     "vault_version_number": "1.3.0",
     "sig_replication_regions": "East US",
-    "sig_version": "0.0.3"
+    "sig_version": "0.0.4"
 }


### PR DESCRIPTION
This is an example PR to showcase the decision to delete images created during a PR. There are other ways to solve this problem. [Ideally a 'dry-run' feature would be baked into Packer](https://github.com/hashicorp/packer/issues/7209).

We delete artifacts (images) created by PR CI runs to avoid the 3 C's:
- Congestion: PRs with multiple commits will publish multiple images
- Confusion: With all the extra images you will undoubtedly have a hard time knowing which to use and may even use a bad or outdated image
- Cost: You pay for every image you publish and maintain

Stated plainly, PRs are opportunities to review code before it is added to your master branch. If you consider that _artifacts_ are yielded from the code, the same logic also follows, artifacts outputted from PR CIs should also be used for review opportunity